### PR TITLE
Display more recipes + bug fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -76,7 +76,7 @@ html{
 
 /* new recipe */
 
-.stepsButton{
+.stepsButton {
   text-align: center;
   border: none;
   border-radius: 50%;
@@ -84,6 +84,32 @@ html{
   font-weight: 1000;
   background-color: lightgray;
   color: black;
+  padding: 15px 27px;
+  margin-left: 8px;
+  margin-right: 8px;
+}
+
+.stepsButtonCurrent {
+  text-align: center;
+  border: 5px solid black;
+  border-radius: 50%;
+  font-size: 30px;
+  font-weight: 1000;
+  background-color: lightgray;
+  color: black;
+  padding: 15px 27px;
+  margin-left: 8px;
+  margin-right: 8px;
+}
+
+.stepsButtonDone {
+  text-align: center;
+  border: none;
+  border-radius: 50%;
+  font-size: 30px;
+  font-weight: 1000;
+  background-color: rgb(35, 35, 35);
+  color: #CACACA;
   padding: 15px 27px;
   margin-left: 8px;
   margin-right: 8px;

--- a/src/components/DisplayExistingRecipe.js
+++ b/src/components/DisplayExistingRecipe.js
@@ -112,7 +112,7 @@ function DisplayRecipeSummary({recipeSteps, recipeIndex, currentIngredients, use
         return(
             <div class = "row justify-content-center">
                 <div class = "steps">
-                    {num}
+                    {num+1}
                     {punctuation}
                     {step}
                 </div>

--- a/src/components/DisplayRecipeResults.js
+++ b/src/components/DisplayRecipeResults.js
@@ -58,29 +58,35 @@ function extractRecipeInfo() {
 function DataSetResults({ searchState, setRecipeIndex, changeStep, changeRecipeSteps, currentIngredients, changeCurrentIngredients }) {
 	extractRecipeInfo()
 	const returnValue = [];
-	for (let i = 0; i < data.results[0].recipes.length; i++) {
-		if (searchState === "" || data.results[0].recipes[i].name.toLowerCase().includes(searchState.toLowerCase())) {
-			returnValue.push(<RecipeResult idx={i} setRecipeIndex={setRecipeIndex} changeStep={changeStep} changeRecipeSteps={changeRecipeSteps} currentIngredients={currentIngredients} changeCurrentIngredients= {changeCurrentIngredients}/>)
+	for (let j = 0; j < data.results.length; j++) {
+		if (typeof data.results[j].recipes !== "undefined") {
+			for (let i = 0; i < data.results[j].recipes.length; i++) {
+				if (searchState === "" || data.results[j].recipes[i].name.toLowerCase().includes(searchState.toLowerCase())) {
+					let idx = [j, i];
+					returnValue.push(<RecipeResult idx={idx} setRecipeIndex={setRecipeIndex} changeStep={changeStep} changeRecipeSteps={changeRecipeSteps} currentIngredients={currentIngredients} changeCurrentIngredients= {changeCurrentIngredients}/>)
+				}
+			}
 		}
 	}
+	
 	return returnValue;
 }
 
 function handleRecipeChoice({idx, setRecipeIndex, changeStep, changeRecipeSteps, currentIngredients, changeCurrentIngredients}) {
 	setRecipeIndex(idx);
 
-	let amtSteps = data.results[0].recipes[idx].instructions.length
+	let amtSteps = data.results[idx[0]].recipes[idx[1]].instructions.length
 
 	let steps = []
 
 	for(let i = 0; i<amtSteps; i++){
-		steps.push(data.results[0].recipes[idx].instructions[i].display_text)
+		steps.push(data.results[idx[0]].recipes[idx[1]].instructions[i].display_text)
 	}
 
 	changeRecipeSteps(steps)
 
 	changeStep(2);
-	const allIngredients = data.results[0].recipes[idx].sections[0].components
+	const allIngredients = data.results[idx[0]].recipes[idx[1]].sections[0].components
 	let ingredientArr = [];
 	for (const currKey of Object.keys(allIngredients)) {
 		const currValue = allIngredients[currKey];
@@ -99,14 +105,14 @@ function RecipeResult({ idx, setRecipeIndex, changeStep, changeRecipeSteps, curr
 		<div class="recipe-row">
 			<button class="recipe-options-but" type="button" onClick={() => {handleRecipeChoice({idx, setRecipeIndex, changeStep, changeRecipeSteps, currentIngredients, changeCurrentIngredients})}}>
 				<div class="row">
-					<img class="recipe-options-img" src={data.results[0].recipes[idx].thumbnail_url}></img>
+					<img class="recipe-options-img" src={data.results[idx[0]].recipes[idx[1]].thumbnail_url}></img>
 				</div>
 				<div class="row">
 					<div class="col-3 recipe-subtitles">
 						Name:
 					</div>
 					<div class="col-9 truncate">
-						{data.results[0].recipes[idx].name}
+						{data.results[idx[0]].recipes[idx[1]].name}
 					</div>
 				</div>
 				<div class="row">
@@ -114,12 +120,12 @@ function RecipeResult({ idx, setRecipeIndex, changeStep, changeRecipeSteps, curr
 						Recipe Steps:
 					</div>
 					<div class="col-6">
-						{data.results[0].recipes[idx].instructions.length}
+						{data.results[idx[0]].recipes[idx[1]].instructions.length}
 					</div>
 				</div>
 			</button>
 			<div class="row">
-				<a class="recipe-subtitles truncate-url" href={data.results[0].recipes[idx].original_video_url}> OG Recipe URL</a>
+				<a class="recipe-subtitles truncate-url" href={data.results[idx[0]].recipes[idx[1]].original_video_url}> OG Recipe URL</a>
 			</div>
 			{/* data.results[0].recipes[0].instructions.count */}
 		</div>

--- a/src/components/DisplayRecipeSteps.js
+++ b/src/components/DisplayRecipeSteps.js
@@ -138,7 +138,7 @@ function DisplayRecipeSteps({ recipeIndex, recipeSteps, changeRecipeSteps }) {
         return (
             <div class="row d-flex justify-content-center w-100" key={num}>
                 <div class="steps">
-                    {num}
+                    {num+1}
                     {punctuation}
                     {step}
                 </div>

--- a/src/components/DisplayRecipeSteps.js
+++ b/src/components/DisplayRecipeSteps.js
@@ -136,7 +136,7 @@ function DisplayRecipeSteps({ recipeIndex, recipeSteps, changeRecipeSteps }) {
 
         let punctuation = ". "
         return (
-            <div class="row justify-content-center" key={num}>
+            <div class="row d-flex justify-content-center w-100" key={num}>
                 <div class="steps">
                     {num}
                     {punctuation}

--- a/src/components/DisplayRecipeSummary.js
+++ b/src/components/DisplayRecipeSummary.js
@@ -24,8 +24,8 @@ function DisplayRecipeSummary({recipeSteps, recipeIndex, currentIngredients, use
     function updateRecipe(recipeIndex, recipeSteps) {
         // for (var i = 0; i < data.results[0].recipes[recipeIndex].sections[0].components.length; i++) {
             update(ref(database,'users/' + user.uid + '/recipe-book'),{
-                [data.results[0].recipes[recipeIndex].name]:  {
-                    recipethumbnail: data.results[0].recipes[recipeIndex].thumbnail_url,
+                [data.results[recipeIndex[0]].recipes[recipeIndex[1]].name]:  {
+                    recipethumbnail: data.results[recipeIndex[0]].recipes[recipeIndex[1]].thumbnail_url,
                     index: recipeIndex,
                     recipe_obj: {
                         steps: recipeSteps,

--- a/src/components/DisplayRecipeSummary.js
+++ b/src/components/DisplayRecipeSummary.js
@@ -134,7 +134,7 @@ function DisplayRecipeSummary({recipeSteps, recipeIndex, currentIngredients, use
         return(
             <div class = "row justify-content-center">
                 <div class = "steps">
-                    {num}
+                    {num+1}
                     {punctuation}
                     {step}
                 </div>

--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -33,6 +33,11 @@ export default function MainMenu() {
         </Card.Body>
       </Card>}
       <Container>
+      <Row>
+          <Card as={Link} to="/hci-recipe-app/newrecipe">
+            <Card.Title style={{ display: 'flex', justifyContent: 'center', padding: '15px' }}>Add a New Recipe</Card.Title>
+          </Card>
+        </Row>
         <Row>
           <Card as={Link} to="/hci-recipe-app/recipebook">
             <Card.Title style={{ display: 'flex', justifyContent: 'center', padding: '15px' }}>View Your Recipe Book</Card.Title>

--- a/src/components/NewRecipe.js
+++ b/src/components/NewRecipe.js
@@ -56,20 +56,33 @@ export default function NewRecipe() {
     function stepsHeader() {
         return (
             <div class="steps-header">
-                <button class='stepsButton' type="button">
+                <button class={handleStepHeaderDisplayClass(1)} type="button" onClick={() => {handleStepHeaderSelect(1)}}>
                     1
                 </button>
-                <button class='stepsButton' type="button">
+                <button class={handleStepHeaderDisplayClass(2)} type="button" onClick={() => {handleStepHeaderSelect(2)}}>
                     2
                 </button>
-                <button class='stepsButton' type="button">
+                <button class={handleStepHeaderDisplayClass(3)} type="button" onClick={() => {handleStepHeaderSelect(3)}}>
                     3
                 </button>
-                <button class='stepsButton' type="button">
+                <button class={handleStepHeaderDisplayClass(4)} type="button" onClick={() => {handleStepHeaderSelect(4)}}>
                     4
                 </button>
             </div>
         )
+    }
+
+    function handleStepHeaderDisplayClass(idx) {
+        return stepsNum > idx ? 'stepsButtonDone' : stepsNum === idx ? 'stepsButtonCurrent' : 'stepsButton';
+    }
+
+    function handleStepHeaderSelect(idx) {
+        if (idx === 1) {
+            changeStep(1);
+        }
+        if (idx > 1 && stepsNum !== 1) {
+            changeStep(idx);
+        }
     }
 
     function tempNextButton() {

--- a/src/components/NewRecipe.js
+++ b/src/components/NewRecipe.js
@@ -87,6 +87,13 @@ export default function NewRecipe() {
         }
     }
 
+    function handleSearchKeyDown(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            submitQuery();
+        }
+    }
+
     function Import() {
         let results = ""
         if (hasResults === true) {
@@ -96,7 +103,7 @@ export default function NewRecipe() {
             <div class="import">
                 <form>
                     <label for="search">Search: </label>
-                    <input type="text" placeholder="Chicken" ref={searchTextRef} ></input>
+                    <input type="text" placeholder="Chicken" ref={searchTextRef} onKeyDown={handleSearchKeyDown}></input>
                     <button type="button" onClick={submitQuery}>Submit</button>
                     {/* <input type = "submit" value = "Enter" onClick={() => flipIt()}></input> */}
                 </form>

--- a/src/components/NewRecipe.js
+++ b/src/components/NewRecipe.js
@@ -29,15 +29,15 @@ export default function NewRecipe() {
     let stepName = "";
     if (stepsNum === 2) {
         theStep = Ingredients()
-        stepName = data.results[0].recipes[currentRecipeIndex].name
+        stepName = data.results[currentRecipeIndex[0]].recipes[currentRecipeIndex[1]].name
         nextStep = tempNextButton();
     } else if (stepsNum === 3) {
         theStep = Steps()
-        stepName = data.results[0].recipes[currentRecipeIndex].name
+        stepName = data.results[currentRecipeIndex[0]].recipes[currentRecipeIndex[1]].name
         nextStep = tempNextButton();
     } else if (stepsNum === 4) {
         theStep = Finalize()
-        stepName = data.results[0].recipes[currentRecipeIndex].name
+        stepName = data.results[currentRecipeIndex[0]].recipes[currentRecipeIndex[1]].name
     }
 
     return (

--- a/src/components/RecipeBook.js
+++ b/src/components/RecipeBook.js
@@ -62,7 +62,7 @@ export default function RecipeBook() {
                     </h5>
                     <div class="row">
 					<div class="col-6 recipe-subtitles">
-						Recipe Diffuculty:
+						Recipe Difficulty:
 					</div>
 					<div class="col-6">
 		                {recipeDifficulty}


### PR DESCRIPTION
Making this PR early for a place to write notes.

Currently:
- Displays all recipes that we pulled from the API, as well as loads their ingredients/steps into their respective states correctly
- Search bar works with hitting enter, should display recipes searched and not refresh the page
- Adjust sizing on recipe steps page to prevent unusual sizing issues.
- Start all steps at 1 instead of 0.
- Make recipe creation header functional and dynamic. Can press on them to change the current step, and displays the current step.

Potential bugs:
- ~~Not sure of interaction with database as it required changing the way recipe index is stored. I think Emily said it is not actually used in the database, but I do know it is stored in some form.~~
- ~~Have not tested full recipe creation beyond getting to the summary page.~~

